### PR TITLE
GitHub Actionsホストランナーにプリインストールされているソフトウェアの検証

### DIFF
--- a/.github/workflows/pre-soft.yml
+++ b/.github/workflows/pre-soft.yml
@@ -1,0 +1,36 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.

--- a/.github/workflows/pre-soft.yml
+++ b/.github/workflows/pre-soft.yml
@@ -1,12 +1,12 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: Check Package CI
 
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
-  push:
-    branches: [ test/preSoft ]
+  # push:
+  #   branches: [ master ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/pre-soft.yml
+++ b/.github/workflows/pre-soft.yml
@@ -6,9 +6,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    branches: [ test/preSoft ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -22,15 +20,5 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
-
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
# Issue
closes #6 

## 検証
マジだった...
現時点でのNode.jsの安定版は16系なのでちょっとだけ古いけどそこまで致命的ではないね。
Yarnは1系だけど2系を必須としないならこれで十分そう。逆にNode.jsのバージョンを固定したい場合なんかは setup-node を使ったほうがいいんだろうね。
```sh
runner@fv-az180-894:~/work/actions-lab/actions-lab$ node -v
v14.18.1
runner@fv-az180-894:~/work/actions-lab/actions-lab$ yarn -v
1.22.17
runner@fv-az180-894:~/work/actions-lab/actions-lab$ npm -v
6.14.15
```
## nvm について
nvmも入ってたから切替ができるのかな？

> Node.js
10.24.1
12.22.7
14.18.1
16.13.0

と思ってnvmコマンドを叩いてもnvmコマンドが見つからなかった。
```
Command 'nvm' not found, did you mean:

  command 'nvme' from deb nvme-cli (1.9-1ubuntu0.1)
  command 'num' from deb quickcal (2.4-1)
  command 'pvm' from deb pvm (3.4.6-2build2)
  command 'nm' from deb binutils (2.34-6ubuntu1.3)
  command 'npm' from deb npm (6.14.4+ds-1ubuntu2)
  command 'lvm' from deb lvm2 (2.03.07-1ubuntu1)
  command 'nam' from deb nam (1.15-5build1)
  command 'nim' from deb nim (1.0.6-1)
  command 'kvm' from deb qemu-kvm (1:4.2-3ubuntu6.18)
  command 'nvim' from deb neovim (0.4.3-3)
  command 'nsm' from deb linuxptp (1.9.2-1)
  command 'vm' from deb mgetty-voice (1.2.1-1)
  command 'nvi' from deb nvi (1.81.6-15build1)

Try: apt install <deb name>
```

`~/.bash_profile` にnvmロード用と思しき記述があったので実行したらnvmコマンドは使えるようにはなった。が、デフォルトしか入っていないような。Checked Tools の 16.13.0 ってのはなんなんだろう。。。
```
runner@fv-az246-304☼:~/work/actions-lab/actions-lab☼nvm list

->       system
default -> system
iojs -> N/A (default)
node -> stable (-> N/A) (default)
unstable -> N/A (default)
```

参考
https://github.com/nvm-sh/nvm#install--update-script

まあ自分でちゃんとやるなら setup-node を使えばいいだけなのでこの件はこれ以上つっこまない。